### PR TITLE
Handle parsing only book names

### DIFF
--- a/lib/pericope.rb
+++ b/lib/pericope.rb
@@ -47,7 +47,7 @@ class Pericope
 
 
   def to_s(options={})
-    "#{book_name} #{well_formatted_reference(options)}"
+    ["#{book_name}", well_formatted_reference(options)].compact.join(" ")
   end
 
   def inspect

--- a/lib/pericope.rb
+++ b/lib/pericope.rb
@@ -140,6 +140,10 @@ class Pericope
       @_fragment_regexp ||= /^(?:(?<chapter>\d{1,3}):)?(?<verse>\d{1,3})?(?<letter>[#{letters}])?$/
     end
 
+    def book_regexp
+      @_book_regexp ||= /#{book_pattern}/i
+    end
+
   private
 
     def book_pattern
@@ -166,6 +170,8 @@ class Pericope
 private
 
   def well_formatted_reference(options={})
+    return nil if ranges.empty?
+
     verse_range_separator = options.fetch(:verse_range_separator, "–") # en-dash
     chapter_range_separator = options.fetch(:chapter_range_separator, "—") # em-dash
     verse_list_separator = options.fetch(:verse_list_separator, ", ")

--- a/lib/pericope/parsing.rb
+++ b/lib/pericope/parsing.rb
@@ -68,6 +68,10 @@ class Pericope
       match_all(text) do |attributes|
         return attributes
       end
+
+      match_book(text) do |attributes|
+        return attributes
+      end
       nil
     end
 

--- a/lib/pericope/parsing.rb
+++ b/lib/pericope/parsing.rb
@@ -23,6 +23,16 @@ class Pericope
           pericopes << pericope
         end
       end
+
+      match_book(text) do |attributes|
+        pericope = Pericope.new(attributes)
+        if block_given?
+          yield pericope
+        else
+          pericopes << pericope
+        end
+      end
+
       block_given? ? text : pericopes
     end
 
@@ -75,6 +85,19 @@ class Pericope
           :ranges => ranges
         }
 
+        yield attributes, match
+      end
+    end
+
+    def match_book(text)
+      text.scan(Pericope.book_regexp) do
+        match = Regexp.last_match
+        book = BOOK_IDS[match.captures.find_index(&:itself)]
+        attributes = {
+          :original_string => match.to_s,
+          :book => book,
+          :ranges => ''
+        }
         yield attributes, match
       end
     end
@@ -180,7 +203,6 @@ class Pericope
     end
   end
 
-
   BOOK_PATTERN = %r{\b(?:
       (?:(?:3|iii|third|3rd)\s*(?:
         (john|joh|jon|jhn|jh|jo|jn)
@@ -238,7 +260,7 @@ class Pericope
       (haggai|ha?gg?)|
       (zechariah?|ze?ch?)|
       (malachi|mal)|
-      (matthew|matt|mat|ma|mt)|
+      \b(matthew|matt|mat|ma|mt)\b|
       (mark|mrk|mk)|
       (luke|luk|lk|lu)|
       (john|joh|jon|jhn|jh|jo|jn)|
@@ -260,5 +282,4 @@ class Pericope
   BOOK_IDS = [ 64, 10, 12, 14, 63, 47, 53, 55, 61, 9, 11, 13, 62, 46, 52, 54, 60, 1, 2, 3, 4, 5, 6,  7, 8, 23, 15, 16, 17, 18, 19, 20, 21, 22, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42, 43, 44, 45, 48, 49, 50, 51, 56, 57, 58, 59, 65, 66 ].freeze
 
   BOOK_NAMES = [nil, "Genesis", "Exodus", "Leviticus", "Numbers", "Deuteronomy", "Joshua", "Judges", "Ruth", "1 Samuel", "2 Samuel", "1 Kings", "2 Kings", "1 Chronicles", "2 Chronicles", "Ezra", "Nehemiah", "Esther", "Job", "Psalm", "Proverbs", "Ecclesiastes", "Song of Solomon", "Isaiah", "Jeremiah", "Lamentations", "Ezekiel", "Daniel", "Hosea", "Joel", "Amos", "Obadiah", "Jonah", "Micah", "Nahum", "Habakkuk", "Zephaniah", "Haggai", "Zechariah", "Malachi", "Matthew", "Mark", "Luke", "John", "Acts", "Romans", "1 Corinthians", "2 Corinthians", "Galatians", "Ephesians", "Philippians", "Colossians", "1 Thessalonians", "2 Thessalonians", "1 Timothy", "2 Timothy", "Titus", "Philemon", "Hebrews", "James", "1 Peter", "2 Peter", "1 John", "2 John", "3 John", "Jude", "Revelation"].freeze
-
 end

--- a/lib/pericope/version.rb
+++ b/lib/pericope/version.rb
@@ -1,3 +1,3 @@
 class Pericope
-  VERSION = "1.0.3" unless defined?(::Pericope::Version)
+  VERSION = "1.1.0" unless defined?(::Pericope::Version)
 end

--- a/pericope.gemspec
+++ b/pericope.gemspec
@@ -5,18 +5,17 @@ $:.unshift lib unless $:.include?(lib)
 require "pericope/version"
 
 Gem::Specification.new do |s|
-  s.name         = "pericope"
+  s.name         = "wcc-pericope"
   s.version      = Pericope::VERSION
   s.platform     = Gem::Platform::RUBY
-  s.authors      = ["Bob Lail"]
-  s.email        = ["bob.lailfamily@gmail.com"]
-  s.homepage     = "http://github.com/boblail/pericope"
+  s.authors      = ["Watermark Community Church"]
+  s.email        = ["dev@watermark.org"]
+  s.homepage     = "https://github.com/watermarkchurch/wcc-pericope"
   s.summary      = "Pericope is a gem for parsing Bible references."
   s.description  = "It recognizes common abbreviations and misspellings for names of the books of the Bible and a variety of ways of denoting ranges of chapters and verses. It can parse pericopes singly or out of a block of text. It's useful for comparing two pericopes for intersection and normalizing them into a well-formatted string."
 
   s.files        = Dir.glob("{bin,data,lib}/**/*") + %w(README.mdown)
   s.executables  = ["pericope"]
-  s.default_executable = "pericope"
   s.require_path = "lib"
 
   s.add_development_dependency "bundler"
@@ -24,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "shoulda-context"
   s.add_development_dependency "pry"
   s.add_development_dependency "minitest", "~> 5.0"
+  s.add_development_dependency "minitest-focus"
   s.add_development_dependency "minitest-reporters"
   s.add_development_dependency "minitest-reporters-turn_reporter"
 end

--- a/test/pericope_test.rb
+++ b/test/pericope_test.rb
@@ -471,6 +471,17 @@ class PericopeTest < Minitest::Test
           assert_equal expected_pericope, Pericope.new(verses).ranges
         end
       end
+
+      should 'accept just book names' do
+        tests = {
+          "Genesis" => "Genesis",
+          "Ruth"    => "Ruth"
+        }
+
+        tests.each do |book, expected_pericope|
+          assert_equal expected_pericope, Pericope.new(book).to_s, "Expected Pericope to parse the entire book of #{book}"
+        end
+      end
     end
 
     context "#to_a" do

--- a/test/pericope_test.rb
+++ b/test/pericope_test.rb
@@ -360,6 +360,10 @@ class PericopeTest < Minitest::Test
         assert_equal "John 1", Pericope.new("john 1").to_s(always_print_verse_range: false)
         assert_equal "John 1:1–51", Pericope.new("john 1").to_s(always_print_verse_range: true)
       end
+
+      should "work with just a book name" do
+        assert_equal "Genesis", Pericope("Genesis").to_s
+      end
     end
   end
 

--- a/test/pericope_test.rb
+++ b/test/pericope_test.rb
@@ -6,6 +6,18 @@ class PericopeTest < Minitest::Test
     Pericope.max_letter = "d"
   end
 
+  describe "Pericope" do
+    it 'can parse an entire book' do
+      tests = {
+        "Genesis" => "Genesis",
+        "Ruth"    => "Ruth"
+      }
+
+      tests.each do |book, expected_pericope|
+        assert_equal expected_pericope, Pericope.parse_one(book).to_s, "Expected Pericope to parse the entire book of #{book}"
+      end
+    end
+  end
 
   context "quickly recognizes Bible references:" do
     context "BOOK_PATTERN" do
@@ -102,6 +114,20 @@ class PericopeTest < Minitest::Test
 
         tests.each do |input, book|
           assert_equal book, Pericope("#{input} 1").book, "Expected Pericope to be able to identify \"#{input}\" as book ##{book}"
+        end
+      end
+
+      should "return an integer identifying the book of the Bible when only the book name is given" do
+        tests = {
+          "Romans" => 45,  # Romans
+          "mark"   => 41,  # Mark
+          "ps"     => 19,  # Psalms
+          "jas"    => 59,  # James
+          "ex"     => 2,   # Exodus
+          "ma"     => 40 } # Matthew
+
+        tests.each do |input, book|
+          assert_equal book, Pericope("#{input}")&.book, "Expected Pericope to be able to identify \"#{input}\" as book ##{book}"
         end
       end
     end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -2,8 +2,9 @@ $LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
 require "pericope"
 
 require "minitest/reporters/turn_reporter"
-MiniTest::Reporters.use! Minitest::Reporters::TurnReporter.new
+Minitest::Reporters.use! Minitest::Reporters::TurnReporter.new
 
 require "shoulda/context"
 require "minitest/autorun"
+require "minitest/focus"
 require "pry"


### PR DESCRIPTION
This allows the user to parse JUST the book name if it's needed.

For example, `Pericope.new("Genesis")` will return "Genesis" instead of nil.